### PR TITLE
fixes DocumentReader.processVideoFrame() so that it returns the error…

### DIFF
--- a/RegulaDocumentReader/DocumentReader/src/main/java/com/regula/sdk/DocumentReader.java
+++ b/RegulaDocumentReader/DocumentReader/src/main/java/com/regula/sdk/DocumentReader.java
@@ -202,9 +202,8 @@ public final class DocumentReader {
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
-
-                    return errorcode;
                 }
+                return errorcode;
             }
             return MRZDetectorErrorCode.INPUT_CONTAINER_NULL_POINTER;
         }


### PR DESCRIPTION
… code from JNI

The `return errorcode;` line was contained within the `if (errorcode == MRZDetectorErrorCode.MRZ_RECOGNIZED_CONFIDENTLY) {` block, so it would only get executed if the errorcode was 8.  Otherwise execution would fall through to to the `return MRZDetectorErrorCode.INPUT_CONTAINER_NULL_POINTER;` line.

`return errorcode;` just needs to be outside that conditional block